### PR TITLE
タイトル更新時タイトルの配列要素の不変性を保つための修正

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,10 +21,16 @@
   </div>
 </main>
 
-<script>
+<script lang="ts">
   import Counter from './components/Counter.svelte';
 
-  let counters = [{ id: Date.now(), title: 'new', count: 0 }];
+  interface CounterType {
+    id: number;
+    title: string;
+    count: number;
+  }
+
+  let counters: CounterType[] = [{ id: Date.now(), title: 'new', count: 0 }];
   let titles = ['new'];
 
   $: calculateTotalCount = counters.reduce((total, counter) => total + counter.count, 0);
@@ -51,11 +57,8 @@
     counters = counters.filter(counter => counter.id !== id);
   }
 
-  function updateTitle(event, id) {
-    const index = counters.findIndex(counter => counter.id === id);
-    if (index !== -1) {
-      counters[index].title = event.detail.title;
-    }
+  function updateTitle(id: number, newTitle: string = ''): void {
+    counters = counters.map(counter => counter.id === id ? { ...counter, title: newTitle } : counter);
   }
 </script>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,59 +5,44 @@
       id={counter.id}
       title={counter.title}
       count={counter.count}
-      on:updateCount={handleUpdateCount}
-      on:remove={event => removeCounter(event.detail.id)}
-      on:updateTitle={event => updateTitle(event, counter.id)}
+      on:updateCount={event => handleUpdateCount(counter.id, event.detail.newCount)}
+      on:remove={() => removeCounter(counter.id)}
+      on:updateTitle={event => updateTitle(counter.id, event.detail.newTitle)}
     />
   {/each}
   <div class="container">
-  <button class="new-counter" on:click={addCounter}>new counter</button>
+    <button class="new-counter" on:click={addCounter}>new counter</button>
   </div>
   <div class="title-list">
     title list: {titles.join(', ')}
   </div>
   <div class="sum-count">
-    sum of count: { calculateTotalCount }
+    sum of count: {calculateTotalCount}
   </div>
 </main>
 
 <script lang="ts">
   import Counter from './components/Counter.svelte';
-
-  interface CounterType {
-    id: number;
-    title: string;
-    count: number;
-  }
+  import type { CounterType } from './types';
 
   let counters: CounterType[] = [{ id: Date.now(), title: 'new', count: 0 }];
-  let titles = ['new'];
 
   $: calculateTotalCount = counters.reduce((total, counter) => total + counter.count, 0);
   $: titles = counters.map(c => c.title);
 
-  function handleUpdateCount(event) {
-    const { id, count } = event.detail;
-    const index = counters.findIndex(counter => counter.id === id);
-    if (index !== -1) {
-      counters[index].count = count;
-    }
+  function handleUpdateCount(id: number, newCount: number): void {
+    counters = counters.map(counter => counter.id === id ? { ...counter, count: newCount } : counter);
   }
 
-  function addCounter() {
-    const newCounter = {
-      id: Date.now(),
-      title: 'new',
-      count: 0
-    };
-    counters = [...counters, newCounter];
+  function addCounter(): void {
+    counters = [...counters, { id: Date.now(), title: 'new', count: 0 }];
   }
 
-  function removeCounter(id) {
+  function removeCounter(id: number): void {
     counters = counters.filter(counter => counter.id !== id);
   }
 
-  function updateTitle(id: number, newTitle: string = ''): void {
+  function updateTitle(id: number, newTitle: string): void {
     counters = counters.map(counter => counter.id === id ? { ...counter, title: newTitle } : counter);
   }
 </script>

--- a/src/components/Counter.svelte
+++ b/src/components/Counter.svelte
@@ -7,31 +7,31 @@
   <button class="counter-delete" on:click={remove}>x</button>
 </div>
 
-<script>
+<script lang="ts">
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher();
-  export let title;
-  export let id;
-  export let count;
+  export let title: string;
+  export let id: number;
+  export let count: number;
 
-  $: if (title !== 'new') {
-    dispatch('updateTitle', { title });
-  }
-  $: dispatch('updateCount', { id, count });
+  $: dispatch('updateTitle', { id, newTitle: title });
 
   function increment() {
     count += 1;
+    dispatch('updateCount', { id, newCount: count });
   }
 
   function decrement() {
     if (count > 0) {
       count -= 1;
+      dispatch('updateCount', { id, newCount: count });
     }
   }
 
   function reset() {
     count = 0;
+    dispatch('updateCount', { id, newCount: count });
   }
 
   function remove() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface CounterType {
+  id: number;
+  title: string;
+  count: number;
+}


### PR DESCRIPTION
#### ・このPRには、以下の2つのコミットが含まれています。
#### 1. タイトル更新時の配列要素の不変性を保つための修正
counters配列内の特定のカウンターのタイトルを更新する方法を修正しました。
以前はcounters[index].title = event.detail.title;を使用して直接配列の要素を変更していました。しかし、これはTypeScriptの型安全性を完全に活用していませんでした。
コードの一貫性を維持するため、変更が必要な要素のみを更新した新しい配列を作成し、それを用いて元の配列を置き換えるようにしました。この変更により、バグが発生するリスクが低減します。

#### 2. TypeScriptでコードの可読性を向上
上記の修正を行う中で、TypeScriptの型を十分に活用していないことに気付きました。
TypeScriptの機能をより活用する形でリファクタリングし、コードの可読性と保守性を向上させる修正しました。

どちらのコミットも、TypeScriptの型安全性を最大限に活用するように修正しました。

※ 補足
このPR（issues/9）は、issues/8からブランチを切って作成しました。理由は、issues/8で合計カウント数をリアクティブにするため下のコードへ修正しましたが、issues/9にもこの修正が必要でした。そのため、issues/8のブランチから直接ブランチを切ることで差分が被ることを無くし、コンフリクトのリスクを最小限に抑えるようにしました。
```
$: calculateTotalCount = counters.reduce((total, counter) => total + counter.count, 0); 
$: titles = counters.map(c => c.title); 
```

よろしくお願いします。

close https://github.com/toshinori-m/Multiple_Counter/issues/9